### PR TITLE
Add file permission check & enable GNOME41 support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+    "singleQuote": true,
+    "printWidth": 120
+}

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -3,7 +3,7 @@
 ## Temporary
 
 ```shell
-$ sudo chmod a+w /sys/class/leds/asus::screenpad/brightness
+$ sudo chmod a+rw /sys/class/leds/asus::screenpad/brightness
 ```
 
 ## Permanent (requires udev)
@@ -13,7 +13,7 @@ If you don't use udev, add the command from the temporary section to an init scr
 1. Create this file at `/etc/udev/rules.d/99-screenpad.rules`
 
 ```udev
-ACTION=="add", SUBSYSTEM=="leds", KERNEL=="asus::screenpad", RUN+="/bin/chmod a+w /sys/class/leds/%k/brightness"
+ACTION=="add", SUBSYSTEM=="leds", KERNEL=="asus::screenpad", RUN+="/bin/chmod a+rw /sys/class/leds/%k/brightness"
 ```
 
 2. Apply the new udev rule:

--- a/extension.js
+++ b/extension.js
@@ -35,16 +35,32 @@ class Extension {
                         );
                     }
                 );
-            }
-            if (!false) { // TODO: Check if the current user has permission to write to the brightness file
-                this._showNotification(
-                    'You do not have permission to set the brightness of the Screenpad+',
-                    `The current user does not have write access to the file ${ScreenpadSysfsPath}/brightness.`,
-                    'Click here to see how to configure this',
-                    function () {
-                        Gio.AppInfo.launch_default_for_uri_async('https://github.com/laurinneff/gnome-shell-extension-zenbook-duo/blob/master/docs/permissions.md', null, null, null);
-                    }
+            } else {
+                this._screenpadBrightnessFileInfo = this._screenpadBrightnessFile.query_info(
+                    'access::*',
+                    Gio.FileQueryInfoFlags.NONE,
+                    null
                 );
+
+                // Check to make sure we have both read and write permissions
+                if (
+                    !this._screenpadBrightnessFileInfo.get_attribute_boolean(Gio.FILE_ATTRIBUTE_ACCESS_CAN_READ) ||
+                    !this._screenpadBrightnessFileInfo.get_attribute_boolean(Gio.FILE_ATTRIBUTE_ACCESS_CAN_WRITE)
+                ) {
+                    this._showNotification(
+                        'You do not have permission to set the brightness of the Screenpad+',
+                        `The current user does not have write access to the file ${ScreenpadSysfsPath}/brightness.`,
+                        'Click here to see how to configure this',
+                        function () {
+                            Gio.AppInfo.launch_default_for_uri_async(
+                                'https://github.com/laurinneff/gnome-shell-extension-zenbook-duo/blob/master/docs/permissions.md',
+                                null,
+                                null,
+                                null
+                            );
+                        }
+                    );
+                }
             }
 
             firstRun = false;

--- a/extension.js
+++ b/extension.js
@@ -36,7 +36,7 @@ class Extension {
                     }
                 );
             } else {
-                this._screenpadBrightnessFileInfo = this._screenpadBrightnessFile.query_info(
+                let screenpadBrightnessFileInfo = this._screenpadBrightnessFile.query_info(
                     'access::*',
                     Gio.FileQueryInfoFlags.NONE,
                     null
@@ -44,8 +44,8 @@ class Extension {
 
                 // Check to make sure we have both read and write permissions
                 if (
-                    !this._screenpadBrightnessFileInfo.get_attribute_boolean(Gio.FILE_ATTRIBUTE_ACCESS_CAN_READ) ||
-                    !this._screenpadBrightnessFileInfo.get_attribute_boolean(Gio.FILE_ATTRIBUTE_ACCESS_CAN_WRITE)
+                    !screenpadBrightnessFileInfo.get_attribute_boolean(Gio.FILE_ATTRIBUTE_ACCESS_CAN_READ) ||
+                    !screenpadBrightnessFileInfo.get_attribute_boolean(Gio.FILE_ATTRIBUTE_ACCESS_CAN_WRITE)
                 ) {
                     this._showNotification(
                         'You do not have permission to set the brightness of the Screenpad+',

--- a/extension.js
+++ b/extension.js
@@ -16,19 +16,23 @@ const ScreenpadSysfsPath = '/sys/class/leds/asus::screenpad';
 let firstRun = true;
 
 class Extension {
-    constructor() {
-    }
+    constructor() {}
 
     enable() {
         if (firstRun) {
-            this._screenpadBrightnessFile = Gio.File.new_for_path(`${ScreenpadSysfsPath}/brightness`)
+            this._screenpadBrightnessFile = Gio.File.new_for_path(`${ScreenpadSysfsPath}/brightness`);
             if (!this._screenpadBrightnessFile.query_exists(null)) {
                 this._showNotification(
                     'The Screenpad brightness file does not exist',
                     'Ensure the asus-wmi-screenpad module is installed and loaded and that your device is compatible with this module.',
                     'Click here to see how to do this',
                     function () {
-                        Gio.AppInfo.launch_default_for_uri_async('https://github.com/Plippo/asus-wmi-screenpad#readme', null, null, null);
+                        Gio.AppInfo.launch_default_for_uri_async(
+                            'https://github.com/Plippo/asus-wmi-screenpad#readme',
+                            null,
+                            null,
+                            null
+                        );
                     }
                 );
             }
@@ -48,65 +52,83 @@ class Extension {
 
         this._keybindingManager = new Keybindings.Manager();
 
-        this._keybindingManager.add('Launch7', async function () {
-            try {
-                let brightness = await this._getBrightness();
-                if (brightness === 0) {
-                    // Range from 1 to 255 so the screenpad can't be turned off completely by changing the brightness
-                    this._setBrightness(this._brightnessSlider.value * 254 + 1);
-                } else {
-                    this._setBrightness(0);
+        this._keybindingManager.add(
+            'Launch7',
+            async function () {
+                try {
+                    let brightness = await this._getBrightness();
+                    if (brightness === 0) {
+                        // Range from 1 to 255 so the screenpad can't be turned off completely by changing the brightness
+                        this._setBrightness(this._brightnessSlider.value * 254 + 1);
+                    } else {
+                        this._setBrightness(0);
+                    }
+                } catch (e) {
+                    logError(e);
                 }
-            } catch (e) {
-                logError(e);
-            }
-        }.bind(this));
+            }.bind(this)
+        );
 
-        this._keybindingManager.add('Launch6', function () {
-            // TODO: Swap windows
-            this._showNotification('This key is not implemented yet.');
-        }.bind(this));
+        this._keybindingManager.add(
+            'Launch6',
+            function () {
+                // TODO: Swap windows
+                this._showNotification('This key is not implemented yet.');
+            }.bind(this)
+        );
 
-        this._keybindingManager.add('<Shift><Super>s', function () {
-            // https://gjs.guide/guides/gio/subprocesses.html#basic-usage
+        this._keybindingManager.add(
+            '<Shift><Super>s',
+            function () {
+                // https://gjs.guide/guides/gio/subprocesses.html#basic-usage
 
-            try {
-                // The process starts running immediately after this function is called. Any
-                // error thrown here will be a result of the process failing to start, not
-                // the success or failure of the process itself.
-                let proc = Gio.Subprocess.new(
-                    // The program and command options are passed as a list of arguments
-                    ['gnome-screenshot'],
+                try {
+                    // The process starts running immediately after this function is called. Any
+                    // error thrown here will be a result of the process failing to start, not
+                    // the success or failure of the process itself.
+                    let proc = Gio.Subprocess.new(
+                        // The program and command options are passed as a list of arguments
+                        ['gnome-screenshot'],
 
-                    // The flags control what I/O pipes are opened and how they are directed
-                    Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE
-                );
-            } catch (e) {
-                logError(e);
-            }
-        }.bind(this));
+                        // The flags control what I/O pipes are opened and how they are directed
+                        Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE
+                    );
+                } catch (e) {
+                    logError(e);
+                }
+            }.bind(this)
+        );
 
-        this._keybindingManager.add('Tools', function () {
-            // TODO: Open application, add configuration
-            this._showNotification('This key is not implemented yet.');
-        }.bind(this));
+        this._keybindingManager.add(
+            'Tools',
+            function () {
+                // TODO: Open application, add configuration
+                this._showNotification('This key is not implemented yet.');
+            }.bind(this)
+        );
 
-        this._keybindingManager.add('WebCam', function () {
-            // TODO: Toggle camera
-            this._showNotification('This key is not implemented yet.');
-        }.bind(this));
+        this._keybindingManager.add(
+            'WebCam',
+            function () {
+                // TODO: Toggle camera
+                this._showNotification('This key is not implemented yet.');
+            }.bind(this)
+        );
 
         this._brightnessSlider = imports.ui.main.panel.statusArea.aggregateMenu._brightness._slider;
-        this._brightnessListenerId = this._brightnessSlider.connect('notify::value', async function () {
-            try {
-                if (await this._getBrightness() === 0) return; // Don't turn Screenpad on when it was turned off
+        this._brightnessListenerId = this._brightnessSlider.connect(
+            'notify::value',
+            async function () {
+                try {
+                    if ((await this._getBrightness()) === 0) return; // Don't turn Screenpad on when it was turned off
 
-                // Range from 1 to 255 so the screenpad can't be turned off completely by changing the brightness
-                await this._setBrightness(this._brightnessSlider.value * 254 + 1);
-            } catch (e) {
-                logError(e);
-            }
-        }.bind(this));
+                    // Range from 1 to 255 so the screenpad can't be turned off completely by changing the brightness
+                    await this._setBrightness(this._brightnessSlider.value * 254 + 1);
+                } catch (e) {
+                    logError(e);
+                }
+            }.bind(this)
+        );
     }
 
     disable() {
@@ -121,13 +143,17 @@ class Extension {
             // We have to prepare this only once
             this._notifSource = new MessageTray.SystemNotificationSource();
             // Take care of note leaving unneeded sources
-            this._notifSource.connect('destroy', Lang.bind(this, function () { this._notifSource = null; }));
+            this._notifSource.connect(
+                'destroy',
+                Lang.bind(this, function () {
+                    this._notifSource = null;
+                })
+            );
             Main.messageTray.add(this._notifSource);
         }
         let notification = null;
         notification = new MessageTray.Notification(this._notifSource, title, message);
-        if (btnText)
-            notification.addAction(btnText, Lang.bind(this, btnAction));
+        if (btnText) notification.addAction(btnText, Lang.bind(this, btnAction));
         notification.setTransient(true);
         this._notifSource.showNotification(notification);
     }
@@ -135,14 +161,14 @@ class Extension {
     _getBrightness() {
         return new Promise((resolve, reject) => {
             let [success, brightness] = this._screenpadBrightnessFile.load_contents(null);
-            if (success) resolve(+(imports.byteArray.toString(brightness)));
+            if (success) resolve(+imports.byteArray.toString(brightness));
             else reject();
         });
     }
 
     _setBrightness(brightness) {
         return new Promise((resolve, reject) => {
-            let [success,] = this._screenpadBrightnessFile.replace_contents(
+            let [success] = this._screenpadBrightnessFile.replace_contents(
                 Math.floor(brightness).toString(),
                 null,
                 false,

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,5 @@
   "name": "Asus ZenBook Duo Integration",
   "description": "Integrate the features of the Asus ZenBook Duo into GNOME",
   "uuid": "zenbook-duo@laurinneff.ch",
-  "shell-version": [
-    "40"
-  ]
+  "shell-version": ["41", "40"]
 }


### PR DESCRIPTION
First off; thank you so much for building this extension, it's been a joy to use my UX482 running Fedora and having both screens' brightness synchronize is quite an elegant solution, it almost makes you forget this was achieved with an extension and isn't just how it natively works. Well done! :)

---

As far as I could test with my Zenbook model, your extension seems to work perfectly with GNOME41 too, so this PR adds that version to the whitelist. I also wanted to see if I could add proper file permission checking support. Being new to gnome extension development, this part in particular would probably benefit from a double check on your part.

Lastly, I added basic `.editorconfig` and `.prettierrc` configuration files and tried to have them mostly match your existing coding standards of this project. A few line break changes were applied, but I hope they contribute to the code's readability and git log traversing.

---

I hope it's alright that I made this PR. I'm interested in seeing if we can find some useful functionality for some of the other buttons these Asus keyboards have available. I have never actually used Windows on this laptop, so I'm not sure what the "Tools" button originally did, but there might be some interesting possibilities here -- though these would likely benefit from having customizable settings added too. For example, the "swap windows" button might be extra useful if there was an extension setting that would allow you to choose to either swap all windows, or just the active one. Something like that. 

Anyway, thank you again, and please let me know if you'd like me to make any changes to this PR.