### PR TITLE
Add confirmed UX482EA compatibility note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ This extension requires the [asus-wmi-screenpad](https://github.com/Plippo/asus-
 ```shell
 git clone https://github.com/laurinneff/gnome-shell-extension-zenbook-duo.git
 cd gnome-shell-extension-zenbook-duo
-gnome-extensions pack --extra-source=utils.js --extra-source=keybindings.js
+gnome-extensions pack --extra-source=utils.js --extra-source=keybindings.js --extra-source=prefs.ui
 gnome-extensions install zenbook-duo@laurinneff.ch.shell-extension.zip
 ```

--- a/README.md
+++ b/README.md
@@ -5,11 +5,14 @@
 | Model    | Supported? | Additional notes    | Confirmed by |
 | -------- | :--------: | ------------------- | ------------ |
 | UX481FLY |     ✅     |                     | @laurinneff  |
-| UX482    |     ✅     | Exact model unknown | @jibsaramnim |
+| UX482EA  |     ✅     | without NVIDIA GPU  | @jibsaramnim |
+| UX482EG  |     ❔     | with NVIDIA GPU     |              |
 
-<!-- Use ✅ for supported, ❌ for unsupported -->
+<!-- Use ✅ for supported, ❔ for unknown/unconfirmed, ❌ for unsupported -->
 
 ## Installation
+
+This extension requires the [asus-wmi-screenpad](https://github.com/Plippo/asus-wmi-screenpad) kernel module, please install this first.
 
 ```shell
 git clone https://github.com/laurinneff/gnome-shell-extension-zenbook-duo.git


### PR DESCRIPTION
As [requested](https://github.com/laurinneff/gnome-shell-extension-zenbook-duo/pull/1#issuecomment-968304136). I had to grab the box to figure out what my exact model number is, they're certainly not particularly memorable.

I also pre-added the variant with NVIDIA GPU with a question mark. I have contacted someone who I know has this particular model, but I am not sure if they have used your extension. If I hear back and they did, we'll be able to mark this one as confirmed too. I also thought having a question mark here may encourage someone to create an issue to report compatibility for any other models that might be out there, it'll be nice to have this information gathered here.

I added a brief note under the installation section that mentions the kernel module required. I know the extension itself mentions this at launch, but I thought it might be useful to have it referenced here too.

Lastly, I've also added the new `prefs.ui` file as an `--extra-source` to the pack command described in the README. It seems to be necessary for the settings UI to show up correctly.