### PR TITLE
Ported to Gnome Shell 43

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
   "description": "Integrate the features of the Asus ZenBook Duo into GNOME",
   "uuid": "zenbook-duo@laurinneff.ch",
   "version": "5",
-  "shell-version": ["42", "41", "40"],
+  "shell-version": ["43", "42", "41", "40"],
   "url": "https://github.com/laurinneff/gnome-shell-extension-zenbook-duo"
 }

--- a/schemas/org.gnome.shell.extensions.zenbook-duo.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.zenbook-duo.gschema.xml
@@ -7,6 +7,10 @@
         <value nick="Interactive" value="4" />
     </enum>
     <schema id="org.gnome.shell.extensions.zenbook-duo" path="/org/gnome/shell/extensions/zenbook-duo/">
+        <key name="brightness" type="u">
+            <default>42</default>
+            <summary>Default brightness for 2nd screen</summary>
+        </key>
         <key name="myasus-cmd" type="s">
             <default>''</default>
             <summary>Command to run when the MyASUS key is pressed</summary>


### PR DESCRIPTION
If you have issue with Gsettings / Key missing, you might need to copy gschemas.compiled to ~/.local/share/glib-2.0/schemas/

https://gjs.guide/extensions/upgrading/gnome-shell-43.html#quick-settings

TODO: Get the actual brightness of the 2nd screen and move the slider to the correct position on init of the extension
TODO: Probably code cleaning / logic