### PR TITLE
GNOME 45

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,15 @@
+# Development
+
+## Debugging
+
+For logs run in terminal
+
+```shell
+# extension
+journalctl -f -o cat /usr/bin/gnome-shell
+
+#preferences
+journalctl -f -o cat /usr/bin/gjs
+```
+
+To reload (all) extension press ALT+F2 and enter `restart`

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 6
+VERSION = 7
 
 EXTENSION_INSTALL_DIR = "$(HOME)/.local/share/gnome-shell/extensions/zenbook-duo@laurinneff.ch"
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ EXTENSION_INSTALL_DIR = "$(HOME)/.local/share/gnome-shell/extensions/zenbook-duo
 FILES += extension.js
 FILES += utils.js
 FILES += keybindings.js
+FILES += featureindicator.js
 FILES += prefs.js
 FILES += prefs.ui
 FILES += metadata.json

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 5
+VERSION = 6
 
 EXTENSION_INSTALL_DIR = "$(HOME)/.local/share/gnome-shell/extensions/zenbook-duo@laurinneff.ch"
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Asus ZenBook Duo Integration for GNOME
 
+This GNOME extension adds controlls to Quicksettings, allowing brightness change for second screen of Asus ZenBook Duo.
+
+This is a fork of [mjollnir14/gnome-shell-extension-zenbook-duo](https://github.com/mjollnir14/gnome-shell-extension-zenbook-duo) and [lunaneff/gnome-shell-extension-zenbook-duo](https://github.com/lunaneff/gnome-shell-extension-zenbook-duo), since both repositories seem to be abandoned.
+
+
 ## Supported hardware
 
 | Model    | Supported? | Additional notes                           | Confirmed by |

--- a/README.md
+++ b/README.md
@@ -19,14 +19,16 @@ This is a fork of [mjollnir14/gnome-shell-extension-zenbook-duo](https://github.
 ## Installation
 
 This extension requires the [asus-wmi-screenpad](https://github.com/Plippo/asus-wmi-screenpad) kernel module, please install this first.
-
-[![Get it on GNOME Extensions](https://github.com/andyholmes/gnome-shell-extensions-badge/raw/master/get-it-on-ego.png)](https://extensions.gnome.org/extension/4607/asus-zenbook-duo-integration/)
-
 ```shell
-git clone https://github.com/laurinneff/gnome-shell-extension-zenbook-duo.git
-cd gnome-shell-extension-zenbook-duo
+wget https://github.com/allofmex/gnome-shell-extension-zenbook-duo/archive/refs/tags/v7.zip -O gnome-shell-extension-zenbook-duo.zip
+unzip ./gnome-shell-extension-zenbook-duo.zip
+rm ./gnome-shell-extension-zenbook-duo.zip
+cd gnome-shell-extension-zenbook-duo-7
 make install
 ```
+
+Logout/login
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 ## Supported hardware
 
-| Model    | Supported? | Additional notes   | Confirmed by |
-| -------- | :--------: | ------------------ | ------------ |
-| UX481FLY |     ✅     |                    | @laurinneff  |
-| UX482EA  |     ✅     | without NVIDIA GPU | @jibsaramnim |
-| UX482EG  |     ❔     | with NVIDIA GPU    |              |
+| Model    | Supported? | Additional notes                           | Confirmed by |
+| -------- | :--------: | ------------------------------------------ | ------------ |
+| UX481FLY |     ✅     |                                            | @laurinneff  |
+| UX482EA  |     ✅     | without NVIDIA GPU                         | @jibsaramnim |
+| UX482EG  |     ❔     | with NVIDIA GPU                            |              |
+| UX8402   |     ✅     | without NVIDIA GPU, Ubuntu 23.04           | @allofmex    |
 
 <!-- Use ✅ for supported, ❔ for unknown/unconfirmed, ❌ for unsupported -->
 
@@ -21,3 +22,10 @@ git clone https://github.com/laurinneff/gnome-shell-extension-zenbook-duo.git
 cd gnome-shell-extension-zenbook-duo
 make install
 ```
+
+## Usage
+
+This extension will add a second brightness slider to Quicksettings (where your volume/wifi/... toggles are) to control Screenpad brightness.
+It will also add functionality to some of your Asus hardware keys like Toggle-Screenpad and MyAsus key.
+
+It will **not** link the brightness hardware keys to Screenpad display (as of now).

--- a/README.md
+++ b/README.md
@@ -29,3 +29,14 @@ This extension will add a second brightness slider to Quicksettings (where your 
 It will also add functionality to some of your Asus hardware keys like Toggle-Screenpad and MyAsus key.
 
 It will **not** link the brightness hardware keys to Screenpad display (as of now).
+
+## Debugging
+
+Test if brightness can be set to screenpad at all
+
+```
+echo 255 > '/sys/class/leds/asus::screenpad/brightness'
+```
+
+This should have set screenpad brightness to max (or less if you replace 255 by lower value). If this is not working, check the kernel module mentioned above.
+

--- a/extension.js
+++ b/extension.js
@@ -1,25 +1,22 @@
 'use strict';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
 
-const {Gio, GObject} = imports.gi;
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as MessageTray from 'resource:///org/gnome/shell/ui/messageTray.js';
 
-const Meta = imports.gi.Meta;
-const Shell = imports.gi.Shell;
-const Main = imports.ui.main;
-const MessageTray = imports.ui.messageTray;
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
-
-const Keybindings = Me.imports.keybindings;
-const utils = Me.imports.utils;
-const InstallerCodes = Me.imports.utils.ReturnCodes;
-
-const FeatureIndicator = Me.imports.featureindicator.FeatureIndicator;
+import * as Keybindings from './keybindings.js';
+import {ShellTools} from './utils.js';
+import {SetupUtils} from './utils.js';
+import {ReturnCodes as InstallerCodes} from './utils.js';
+import {FeatureIndicator} from './featureindicator.js';
 
 const ScreenpadSysfsPath = '/sys/class/leds/asus::screenpad';
 
-
-class Extension {
-    constructor() {
+export default class ZenbookDuoExtension extends Extension {
+    constructor(metadata) {
+        super(metadata);
         this._firstRun = true;
     }
 
@@ -51,7 +48,7 @@ class Extension {
             this._firstRun = false;
         }
 
-        this.settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.zenbook-duo');
+        this.settings = this.getSettings('org.gnome.shell.extensions.zenbook-duo');
         // this.settings.connect('changed::brightness',
         //    // no usecase as of now
         //    this._onSettingsChanged.bind(this)
@@ -161,18 +158,31 @@ class Extension {
             }.bind(this)
         );
 
-        this._featureIndicator = new FeatureIndicator(
-            (newValue) => this._onMainScreenSliderChg(newValue),
-            (newValue) => this._onPadSliderChg(newValue),
-            () => this._onLinkedToggle()
-        );
+        if (Main.panel.statusArea.quickSettings._system) {
+            this._initQuickSettingsItems();
+        } else {
+            /*
+            * Quick settings menu is populated asynchronously 
+            * That means that the extension is initialized before built-in quick settings items are added.
+            * We need to delay our own indicator setup until built-in quick settings are available 
+            */
+            GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
+                if (!Main.panel.statusArea.quickSettings._system)
+                    return GLib.SOURCE_CONTINUE;
+                this._initQuickSettingsItems();
+                return GLib.SOURCE_REMOVE;
+            });
+        }
+
+        this.utils = new ShellTools(this);
 
         this.settings.connect(
             'changed::uninstall',
             async function () {
                 if (this.settings.get_boolean('uninstall')) {
                     log('Uninstalling additional screenpad files');
-                    switch (await utils.uninstall()) {
+                    let setupUtils = new SetupUtils(this);
+                    switch (await setupUtils.uninstall()) {
                         case InstallerCodes.EXIT_SUCCESS:
                             this._showNotification(
                                 'Successfully uninstalled files',
@@ -191,20 +201,7 @@ class Extension {
             }.bind(this)
         );
 
-        let isLinked = this.settings.get_boolean('link-brightness');
-        this._featureIndicator.setLinkedStatus(isLinked);
-        if (isLinked) {
-            this._featureIndicator.setScreenpadSliderValue(
-                // set slider to stored adjust-value and trigger update
-                this.settings.get_uint('brightness') / 100.0, true);
-        } else {
-            this._getBrightness().then(brightness => {
-                // set slider to screenpads real brightness
-                this._featureIndicator.setScreenpadSliderValue(brightness / 255.0, false);
-            });
-        }
-
-        utils.getProductName().then((productName) => {
+        this.utils.getProductName().then((productName) => {
             log('Zenbook-Duo extension is running on '+productName);
             // this maybe used in future for product line specific adjustmens.
             // E.g. the original extension used keybinding key 'Tools' for MyASUS key
@@ -228,6 +225,29 @@ class Extension {
         this.settings = null;
     }
 
+    _initQuickSettingsItems() {
+        this._featureIndicator = new FeatureIndicator(
+            (newValue) => this._onMainScreenSliderChg(newValue),
+            (newValue) => this._onPadSliderChg(newValue),
+            () => this._onLinkedToggle()
+        );
+        // Add the indicator to the panel
+        Main.panel.statusArea.quickSettings.addExternalIndicator(this._featureIndicator, 2);
+
+        let isLinked = this.settings.get_boolean('link-brightness');
+        this._featureIndicator.setLinkedStatus(isLinked);
+        if (isLinked) {
+            this._featureIndicator.setScreenpadSliderValue(
+                // set slider to stored adjust-value and trigger update
+                this.settings.get_uint('brightness') / 100.0, true);
+        } else {
+            this._getBrightness().then(brightness => {
+                // set slider to screenpads real brightness
+                this._featureIndicator.setScreenpadSliderValue(brightness / 255.0, false);
+            });
+        }
+     }
+
     _onMainScreenSliderChg(sliderValue) {
         let isLinked = this.settings.get_boolean('link-brightness');
         //log('onMainScreenSliderChg '+newValue+' isLinked:'+isLinked);
@@ -247,7 +267,9 @@ class Extension {
             let targetValue = Math.pow(sliderValue, (offset+1));
             //log('main '+sliderValue.toFixed(2)+ ' offset '+offset.toFixed(2)+' new '+targetValue.toFixed(2));
             let adjusted = Math.max(Math.floor(targetValue*255), 1);
-            this._setBrightness(adjusted, false);
+            this._setBrightness(adjusted, false).catch((error) => {
+                logError(e);
+            });
         }
     }
 
@@ -275,7 +297,8 @@ class Extension {
 
     _checkInstalled() {
         log('Checking if additional screenpad files are installed');
-        utils.checkInstalled().then((result) => {
+        let setupUtils = new SetupUtils(this);
+        setupUtils.checkInstalled().then((result) => {
             switch (result) {
                 case InstallerCodes.EXIT_SUCCESS:
                     // Only check for the udev rule if the additional files are installed
@@ -302,7 +325,7 @@ class Extension {
                         "In order for this extension to work, it needs to install some files. You can undo this in the extension's settings.",
                         'Click here to do this automatically',
                         async function () {
-                            switch (await utils.install()) {
+                            switch (await setupUtils.install()) {
                                 case InstallerCodes.EXIT_SUCCESS:
                                     this._showNotification(
                                         'Successfully installed files',
@@ -325,7 +348,7 @@ class Extension {
                         'The extension has been updated, but the additional files need to be updated separately.',
                         'Click here to do this automatically',
                         async function () {
-                            switch (await utils.install()) {
+                            switch (await setupUtils.install()) {
                                 case InstallerCodes.EXIT_SUCCESS:
                                     this._showNotification(
                                         'Successfully updated files',
@@ -365,7 +388,7 @@ class Extension {
     }
 
     async _getBrightness() {
-        const ret = await utils.runScreenpadTool(false, 'get');
+        const ret = await this.utils.runScreenpadTool(false, 'get');
         return +ret.stdout;
     }
 
@@ -376,7 +399,7 @@ class Extension {
     async _setBrightness(brightness, forced) {
         const curr = await this._getBrightness();
         if (forced || curr !== 0) {
-            const ret = await utils.runScreenpadTool(true, 'set', Math.floor(brightness).toString());
+            const ret = await this.utils.runScreenpadTool(true, 'set', Math.floor(brightness).toString());
             return ret.ok;
         }
         return true;

--- a/extension.js
+++ b/extension.js
@@ -132,16 +132,17 @@ class Extension {
 
         // MyASUS key
         this._keybindingManager.add(
-            'Tools',
+            'Launch1',
             function () {
                 try {
+                    let cmd = this.settings.get_string('myasus-cmd');
+                    log('Firing cmd '+cmd);
                     // The process starts running immediately after this function is called. Any
                     // error thrown here will be a result of the process failing to start, not
                     // the success or failure of the process itself.
                     let proc = Gio.Subprocess.new(
                         // The program and command options are passed as a list of arguments
-                        ['sh', '-c', this.settings.get_string('myasus-cmd')],
-
+                        ['sh', '-c', cmd],
                         // The flags control what I/O pipes are opened and how they are directed
                         Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE
                     );
@@ -202,6 +203,17 @@ class Extension {
                 this._featureIndicator.setScreenpadSliderValue(brightness / 255.0, false);
             });
         }
+
+        utils.getProductName().then((productName) => {
+            log('Zenbook-Duo extension is running on '+productName);
+            // this maybe used in future for product line specific adjustmens.
+            // E.g. the original extension used keybinding key 'Tools' for MyASUS key
+            // but for UX8402 it is 'Launch1'.
+            // It is not clear if this was changed for all zenbooks, or only on 
+            // newer versions.
+        }).catch((error) => {
+            log(error);
+        });
     }
 
     disable() {

--- a/extension.js
+++ b/extension.js
@@ -69,9 +69,9 @@ class Extension {
                         let sliderBrightness = this._featureIndicator.getScreenpadSliderBrightness();
                         let adjustedBrightness = Math.floor(sliderBrightness*255);
                         // 1 to 255, so the screenpad will always turn on
-                        this._setBrightness(Math.max(adjustedBrightness, 1));
+                        this._setBrightness(Math.max(adjustedBrightness, 1), true);
                     } else {
-                        this._setBrightness(0);
+                        this._setBrightness(0, true);
                     }
                 } catch (e) {
                     logError(e);
@@ -247,7 +247,7 @@ class Extension {
             let targetValue = Math.pow(sliderValue, (offset+1));
             //log('main '+sliderValue.toFixed(2)+ ' offset '+offset.toFixed(2)+' new '+targetValue.toFixed(2));
             let adjusted = Math.max(Math.floor(targetValue*255), 1);
-            this._setBrightness(adjusted);
+            this._setBrightness(adjusted, false);
         }
     }
 
@@ -260,7 +260,7 @@ class Extension {
             this._onMainScreenSliderChg(this._featureIndicator.getMainSliderBrightness());
         } else {
             let adjusted = Math.max(Math.floor(newValue*255), 1);
-            this._setBrightness(adjusted);
+            this._setBrightness(adjusted, true);
         }
     }
 
@@ -369,9 +369,17 @@ class Extension {
         return +ret.stdout;
     }
 
-    async _setBrightness(brightness) {
-        const ret = await utils.runScreenpadTool(true, 'set', Math.floor(brightness).toString());
-        return ret.ok;
+    /**
+     * @param brightness traget brightness (0-256)
+     * @param forced true to set value, even if screenpad is turned off (may turn on)
+     */
+    async _setBrightness(brightness, forced) {
+        const curr = await this._getBrightness();
+        if (forced || curr !== 0) {
+            const ret = await utils.runScreenpadTool(true, 'set', Math.floor(brightness).toString());
+            return ret.ok;
+        }
+        return true;
     }
 }
 

--- a/featureindicator.js
+++ b/featureindicator.js
@@ -1,8 +1,8 @@
-const {GObject} = imports.gi;
-const QuickSettings = imports.ui.quickSettings;
-// This is the live instance of the Quick Settings menu
-const QuickSettingsMenu = imports.ui.main.panel.statusArea.quickSettings;
+import GObject from 'gi://GObject';
+import * as QuickSettings from 'resource:///org/gnome/shell/ui/quickSettings.js';
+import {panel} from 'resource:///org/gnome/shell/ui/main.js';
 
+const QuickSettingsMenu = panel.statusArea.quickSettings;
 
 const FeatureSlider = GObject.registerClass(
 class FeatureSlider extends QuickSettings.QuickSlider {
@@ -49,7 +49,7 @@ class FeatureSlider extends QuickSettings.QuickSlider {
     }
 });
 
-var FeatureIndicator = GObject.registerClass(
+export const FeatureIndicator = GObject.registerClass(
 class FeatureIndicator extends QuickSettings.SystemIndicator {
     _init(onMainSliderChgCb, onPadSliderChgCb, onSliderBtnClickCb) {
         super._init();
@@ -63,12 +63,11 @@ class FeatureIndicator extends QuickSettings.SystemIndicator {
             this.quickSettingsItems.forEach(item => item.destroy());
         });
 
-        // Add the indicator to the panel
-        QuickSettingsMenu._indicators.add_child(this);
-
         // Add the slider to the menu, this time passing `2` as the second
         // argument to ensure the slider spans both columns of the menu
-        QuickSettingsMenu._addItems(this.quickSettingsItems, 2);
+        for(const item of this.quickSettingsItems) {
+            QuickSettingsMenu.menu.addItem(item, 1);
+        }
 
         this.mainBrightnessSlider = null;
         const mainBrightnessItem = this._findMainBrightnessItem();

--- a/featureindicator.js
+++ b/featureindicator.js
@@ -1,0 +1,117 @@
+const {GObject} = imports.gi;
+const QuickSettings = imports.ui.quickSettings;
+// This is the live instance of the Quick Settings menu
+const QuickSettingsMenu = imports.ui.main.panel.statusArea.quickSettings;
+
+
+const FeatureSlider = GObject.registerClass(
+class FeatureSlider extends QuickSettings.QuickSlider {
+    _init(onSliderChgCb, onBtnClickCb) {
+        log('FeatureSlider._init');
+        
+        super._init({
+            iconName: 'night-light-symbolic',
+            iconReactive: true,
+            //menuEnabled: true,
+        });
+
+        // Set an accessible name for the slider
+        this.slider.accessible_name = 'Brightness';
+        
+        this._sliderChangedId = this.slider.connect('notify::value',
+            () => onSliderChgCb(this.getValue())
+        );
+
+        this._sliderIconClickedId = this.connect('icon-clicked',
+            () => onBtnClickCb()
+        );
+    }
+
+    setValue(sliderValue, notify) {
+        // sliderValue: 0.0 - 1.0
+        if (!notify) {
+            this.slider.block_signal_handler(this._sliderChangedId);
+        }
+        //log('padSliderUpdate '+this.slider.value + ', notify:'+notify);
+        this.slider.value = sliderValue;
+        if (!notify) {
+            this.slider.unblock_signal_handler(this._sliderChangedId);
+        }
+    }
+
+    getValue() {
+        // 0.0 - 1.0
+        return this.slider.value;
+    }
+
+    setLinkedStatus(isLinked) {
+        this.iconName = isLinked ? 'changes-prevent-symbolic' : 'night-light-symbolic';  // or 'night-light-disabled-symbolic'
+    }
+});
+
+var FeatureIndicator = GObject.registerClass(
+class FeatureIndicator extends QuickSettings.SystemIndicator {
+    _init(onMainSliderChgCb, onPadSliderChgCb, onSliderBtnClickCb) {
+        super._init();
+
+        // Create the slider and associate it with the indicator, being sure to
+        // destroy it along with the indicator
+        this._brightnessSlider = new FeatureSlider(onPadSliderChgCb, onSliderBtnClickCb);
+        this.quickSettingsItems.push(this._brightnessSlider);
+
+        this.connect('destroy', () => {
+            this.quickSettingsItems.forEach(item => item.destroy());
+        });
+
+        // Add the indicator to the panel
+        QuickSettingsMenu._indicators.add_child(this);
+
+        // Add the slider to the menu, this time passing `2` as the second
+        // argument to ensure the slider spans both columns of the menu
+        QuickSettingsMenu._addItems(this.quickSettingsItems, 2);
+
+        this.mainBrightnessSlider = null;
+        const mainBrightnessItem = this._findMainBrightnessItem();
+        if (mainBrightnessItem !== null) {
+            // position screenpad-slider below main brightness slider
+            QuickSettingsMenu.menu._grid.set_child_above_sibling(
+                this._brightnessSlider, mainBrightnessItem);
+    
+            this.mainBrightnessSlider = mainBrightnessItem.slider;
+            this._sliderChangedId = this.mainBrightnessSlider.connect('notify::value',
+                () => onMainSliderChgCb(this.getMainSliderBrightness())
+            );
+        } else {
+            log('Zenbook-Duo extension could not find main brightness slider. Linking brightness is not possible!');
+        }
+    }
+
+    getMainSliderBrightness() {
+        // 0.0 - 1.0
+        return this.mainBrightnessSlider !== null ?  this.mainBrightnessSlider.value : -1;
+    }
+
+    getScreenpadSliderBrightness() {
+        // 0.0 - 1.0
+        return this._brightnessSlider.getValue();
+    }
+
+    setScreenpadSliderValue(value, notify) {
+        this._brightnessSlider.setValue(value, notify);
+    }
+
+    setLinkedStatus(isLinked) {
+        this._brightnessSlider.setLinkedStatus(isLinked);
+    }
+
+    _findMainBrightnessItem() {
+        // search for gnomes default brightness slider (don't know a better was as of now)
+        for (const item of QuickSettingsMenu.menu._grid.get_children()) {
+            let name = item.constructor.name.toString();
+            if (name.includes('Brightness') && item.hasOwnProperty('slider')) {
+                return item;
+            }
+        }
+        return null;
+    }
+});

--- a/keybindings.js
+++ b/keybindings.js
@@ -2,11 +2,9 @@
 
 // Shamlessly stolen from https://github.com/GSConnect/gnome-shell-extension-gsconnect/blob/37994f2f12720d8adbe5c633210c930a2bbbaf67/src/shell/keybindings.js
 
-const Config = imports.misc.config;
-const Main = imports.ui.main;
-const Meta = imports.gi.Meta;
-const Shell = imports.gi.Shell;
-
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import Meta from 'gi://Meta';
+import Shell from 'gi://Shell';
 
 /**
  * Keybindings.Manager is a simple convenience class for managing keyboard
@@ -23,7 +21,7 @@ const Shell = imports.gi.Shell;
  *     https://developer.gnome.org/meta/stable/meta-MetaKeybinding.html
  *     https://gitlab.gnome.org/GNOME/gnome-shell/blob/master/js/ui/windowManager.js#L1093-1112
  */
-var Manager = class Manager {
+export const Manager = class Manager {
 
     constructor() {
         this._keybindings = new Map();

--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
   "description": "Integrate the features of the Asus ZenBook Duo into GNOME",
   "uuid": "zenbook-duo@laurinneff.ch",
   "version": "5",
-  "shell-version": ["42", "41", "40"],
+  "shell-version": ["43", "42", "41", "40"],
   "url": "https://github.com/laurinneff/gnome-shell-extension-zenbook-duo"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "Asus ZenBook Duo Integration",
   "description": "Integrate the features of the Asus ZenBook Duo into GNOME",
   "uuid": "zenbook-duo@laurinneff.ch",
-  "version": "5",
+  "version": "6",
   "shell-version": ["44", "43", "42", "41", "40"],
   "url": "https://github.com/laurinneff/gnome-shell-extension-zenbook-duo"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
   "description": "Integrate the features of the Asus ZenBook Duo into GNOME",
   "uuid": "zenbook-duo@laurinneff.ch",
   "version": "5",
-  "shell-version": ["43", "42", "41", "40"],
+  "shell-version": ["44", "43", "42", "41", "40"],
   "url": "https://github.com/laurinneff/gnome-shell-extension-zenbook-duo"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "name": "Asus ZenBook Duo Integration",
   "description": "Integrate the features of the Asus ZenBook Duo into GNOME",
   "uuid": "zenbook-duo@laurinneff.ch",
-  "version": "6",
-  "shell-version": ["44", "43", "42", "41", "40"],
+  "version": "7",
+  "shell-version": ["45"],
   "url": "https://github.com/laurinneff/gnome-shell-extension-zenbook-duo"
 }

--- a/prefs.js
+++ b/prefs.js
@@ -1,76 +1,77 @@
 'use strict';
+import Gtk from 'gi://Gtk';
+import Gio from 'gi://Gio';
 
-const Gtk = imports.gi.Gtk;
-const Gio = imports.gi.Gio;
+import {ExtensionPreferences} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
 
-const ExtensionUtils = imports.misc.extensionUtils;
-const Me = ExtensionUtils.getCurrentExtension();
+export default class ZenbookDuoExtPreferences extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+        window._settings = this.getSettings('org.gnome.shell.extensions.zenbook-duo');
+        window.add(this.getPrefsWidget());
+    }
 
-let settings;
+    getPrefsWidget() {
+        let buildable = new Gtk.Builder();
+        buildable.add_from_file(this.dir.get_path() + '/prefs.ui');
+        let box = buildable.get_object('prefs_widget');
 
-function init() {
-    settings = ExtensionUtils.getSettings('org.gnome.shell.extensions.zenbook-duo');
-}
+        let version_label = buildable.get_object('version_label');
+        version_label.set_text(`Version ${this.metadata.version.toString()}`);
 
-function buildPrefsWidget() {
-    let buildable = new Gtk.Builder();
-    buildable.add_from_file(Me.dir.get_path() + '/prefs.ui');
-    let box = buildable.get_object('prefs_widget');
+        let settings = this.getSettings('org.gnome.shell.extensions.zenbook-duo');
 
-    let version_label = buildable.get_object('version_label');
-    version_label.set_text(`Version ${Me.metadata.version.toString()}`);
+        settings.bind('myasus-cmd', buildable.get_object('entry_myasus_cmd'), 'text', Gio.SettingsBindFlags.DEFAULT);
 
-    settings.bind('myasus-cmd', buildable.get_object('entry_myasus_cmd'), 'text', Gio.SettingsBindFlags.DEFAULT);
+        settings.connect('changed::screenshot-type', () => this.update_screenshot_type_buttons(buildable));
+        this.update_screenshot_type_buttons(buildable, settings);
 
-    settings.connect('changed::screenshot-type', () => update_screenshot_type_buttons(buildable));
-    update_screenshot_type_buttons(buildable);
+        const screenshot_screen = buildable.get_object('screenshot_screen');
+        screenshot_screen.connect('toggled', (x) => {
+            if (screenshot_screen.get_active()) settings.set_string('screenshot-type', 'Screen');
+        });
+        const screenshot_window = buildable.get_object('screenshot_window');
+        screenshot_window.connect('toggled', (x) => {
+            if (screenshot_window.get_active()) settings.set_string('screenshot-type', 'Window');
+        });
+        const screenshot_selection = buildable.get_object('screenshot_selection');
+        screenshot_selection.connect('toggled', (x) => {
+            if (screenshot_selection.get_active()) settings.set_string('screenshot-type', 'Selection');
+        });
+        const screenshot_interactive = buildable.get_object('screenshot_interactive');
+        screenshot_interactive.connect('toggled', (x) => {
+            if (screenshot_interactive.get_active()) settings.set_string('screenshot-type', 'Interactive');
+        });
 
-    const screenshot_screen = buildable.get_object('screenshot_screen');
-    screenshot_screen.connect('toggled', (x) => {
-        if (screenshot_screen.get_active()) settings.set_string('screenshot-type', 'Screen');
-    });
-    const screenshot_window = buildable.get_object('screenshot_window');
-    screenshot_window.connect('toggled', (x) => {
-        if (screenshot_window.get_active()) settings.set_string('screenshot-type', 'Window');
-    });
-    const screenshot_selection = buildable.get_object('screenshot_selection');
-    screenshot_selection.connect('toggled', (x) => {
-        if (screenshot_selection.get_active()) settings.set_string('screenshot-type', 'Selection');
-    });
-    const screenshot_interactive = buildable.get_object('screenshot_interactive');
-    screenshot_interactive.connect('toggled', (x) => {
-        if (screenshot_interactive.get_active()) settings.set_string('screenshot-type', 'Interactive');
-    });
+        settings.bind(
+            'screenshot-include-cursor',
+            buildable.get_object('switch_screenshot_cursor'),
+            'active',
+            Gio.SettingsBindFlags.DEFAULT
+        );
 
-    settings.bind(
-        'screenshot-include-cursor',
-        buildable.get_object('switch_screenshot_cursor'),
-        'active',
-        Gio.SettingsBindFlags.DEFAULT
-    );
+        settings.set_boolean('uninstall', false); // clear dangling flags if a previous request failed
+        const button_uninstall = buildable.get_object('button_uninstall');
+        button_uninstall.connect('clicked', () => {
+            settings.set_boolean('uninstall', true);
+        });
 
-    settings.set_boolean('uninstall', false); // clear dangling flags if a previous request failed
-    const button_uninstall = buildable.get_object('button_uninstall');
-    button_uninstall.connect('clicked', () => {
-        settings.set_boolean('uninstall', true);
-    });
+        return box;
+    }
 
-    return box;
-}
-
-function update_screenshot_type_buttons(buildable) {
-    switch (settings.get_string('screenshot-type')) {
-        case 'Screen':
-            buildable.get_object('screenshot_screen').set_active(true);
-            break;
-        case 'Window':
-            buildable.get_object('screenshot_window').set_active(true);
-            break;
-        case 'Selection':
-            buildable.get_object('screenshot_selection').set_active(true);
-            break;
-        case 'Interactive':
-            buildable.get_object('screenshot_interactive').set_active(true);
-            break;
+    update_screenshot_type_buttons(buildable, settings) {
+        switch (settings.get_string('screenshot-type')) {
+            case 'Screen':
+                buildable.get_object('screenshot_screen').set_active(true);
+                break;
+            case 'Window':
+                buildable.get_object('screenshot_window').set_active(true);
+                break;
+            case 'Selection':
+                buildable.get_object('screenshot_selection').set_active(true);
+                break;
+            case 'Interactive':
+                buildable.get_object('screenshot_interactive').set_active(true);
+                break;
+        }
     }
 }

--- a/prefs.js
+++ b/prefs.js
@@ -49,6 +49,7 @@ function buildPrefsWidget() {
         Gio.SettingsBindFlags.DEFAULT
     );
 
+    settings.set_boolean('uninstall', false); // clear dangling flags if a previous request failed
     const button_uninstall = buildable.get_object('button_uninstall');
     button_uninstall.connect('clicked', () => {
         settings.set_boolean('uninstall', true);

--- a/prefs.ui
+++ b/prefs.ui
@@ -2,9 +2,8 @@
 <!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.24" />
-  <object class="GtkBox" id="prefs_widget">
+  <object class="AdwPreferencesPage" id="prefs_widget">
     <property name="can-focus">True</property>
-    <property name="orientation">vertical</property>
     <child>
       <object class="GtkScrolledWindow">
         <property name="visible">True</property>

--- a/schemas/org.gnome.shell.extensions.zenbook-duo.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.zenbook-duo.gschema.xml
@@ -11,6 +11,10 @@
             <default>42</default>
             <summary>Default brightness for 2nd screen</summary>
         </key>
+        <key name="link-brightness" type="b">
+            <default>true</default>
+            <summary>Default setting if 2nd screen brightness is linked to main screen brightness</summary>
+        </key>
         <key name="myasus-cmd" type="s">
             <default>''</default>
             <summary>Command to run when the MyASUS key is pressed</summary>

--- a/schemas/org.gnome.shell.extensions.zenbook-duo.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.zenbook-duo.gschema.xml
@@ -7,6 +7,10 @@
         <value nick="Interactive" value="4" />
     </enum>
     <schema id="org.gnome.shell.extensions.zenbook-duo" path="/org/gnome/shell/extensions/zenbook-duo/">
+        <key name="brightness" type="u">
+            <default>42</default>
+            <summary>Default brightness for 2nd screen</summary>
+        </key>
         <key name="myasus-cmd" type="s">
             <default>''</default>
             <summary>Command to run when the MyASUS key is pressed</summary>

--- a/utils.js
+++ b/utils.js
@@ -1,44 +1,78 @@
 // A lot of code in this file is adapted from https://github.com/deinstapel/cpupower
 
-const GLib = imports.gi.GLib;
-const Gio = imports.gi.Gio;
-const ExtensionUtils = imports.misc.extensionUtils;
+import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
 
-const Me = ExtensionUtils.getCurrentExtension(),
-    EXTENSIONDIR = Me.dir.get_path(),
-    INSTALLER = `${EXTENSIONDIR}/scripts/installer.sh`,
-    TOOL_SUFFIX = GLib.get_user_name(),
-    PKEXEC = GLib.find_program_in_path('pkexec'),
-    SH = GLib.find_program_in_path('sh');
+export class ShellTools {
 
-function spawnProcessCheckExitCode(...argv) {
-    return new Promise((resolve, reject) => {
-        let [ok, pid, stdin, stdout, stderr] = GLib.spawn_async(
-            EXTENSIONDIR,
-            argv,
-            null,
-            GLib.SpawnFlags.DO_NOT_REAP_CHILD,
-            null
-        );
-        if (!ok) {
-            reject();
-            return;
-        }
-        GLib.child_watch_add(GLib.PRIORITY_DEFAULT, pid, (process, exitStatus) => {
-            GLib.spawn_close_pid(process);
-            let exitCode = 0;
-            try {
-                GLib.spawn_check_exit_status(exitStatus);
-            } catch (e) {
-                exitCode = e.code;
+    /**
+     * 
+     * @param {Extension} extension 
+     */
+    constructor(extension) {
+        this.extension = extension;
+        this.EXTENSIONDIR = extension.dir.get_path();
+        this.TOOL_SUFFIX = GLib.get_user_name();
+        this.PKEXEC = GLib.find_program_in_path('pkexec');
+    }
+
+    runScreenpadTool(pkexecNeeded, ...params) {
+        return this.runShellCmd(pkexecNeeded, '/usr/local/bin/screenpad-' + this.TOOL_SUFFIX, ...params);
+    }
+
+    /**
+     * Reads device product name (like 'Zenbook UX8402ZA_UX8402ZA')
+     */
+    async getProductName() {
+        const ret = await this.runShellCmd(false, 'cat', '/sys/devices/virtual/dmi/id/product_name');
+        return ret.ok ? ret.stdout : null;
+    }
+
+    runShellCmd(pkexecNeeded, cmd, ...params) {
+        return new Promise((resolve, reject) => {
+            let args = [cmd].concat(params);
+    
+            if (pkexecNeeded) {
+                args.unshift(this.PKEXEC);
             }
-
-            resolve(exitCode);
+    
+            let launcher = Gio.SubprocessLauncher.new(Gio.SubprocessFlags.STDOUT_PIPE);
+            launcher.set_cwd(this.EXTENSIONDIR);
+            let proc;
+            try {
+                proc = launcher.spawnv(args);
+            } catch (e) {
+                reject(e);
+                return;
+            }
+    
+            let stdoutStream = new Gio.DataInputStream({
+                base_stream: proc.get_stdout_pipe(),
+                close_base_stream: true,
+            });
+            proc.wait_async(null, (proc, result) => {
+                // this only throws if async call got cancelled, but we
+                // explicitly passed null for the cancellable
+                let ok = proc.wait_finish(result);
+                if (!ok) {
+                    reject();
+                    return;
+                }
+    
+                let exitCode = proc.get_exit_status();
+                let [stdout, _length] = stdoutStream.read_upto('', 0, null);
+    
+                resolve({
+                    ok: exitCode === 0,
+                    exitCode,
+                    stdout,
+                });
+            });
         });
-    });
+    }
 }
 
-var ReturnCodes = Object.freeze({
+export const ReturnCodes = Object.freeze({
     EXIT_SUCCESS : 0,
     EXIT_INVALID_ARGUMENT : 1,
     EXIT_FAILURE : 2,
@@ -47,101 +81,88 @@ var ReturnCodes = Object.freeze({
     EXIT_NEEDS_ROOT : 5,
 });
 
-function checkInstalled() {
-    return spawnProcessCheckExitCode(
-        SH,
-        INSTALLER,
-        '--prefix',
-        '/usr',
-        '--suffix',
-        TOOL_SUFFIX,
-        '--extension-path',
-        EXTENSIONDIR,
-        'check'
-    );
-}
+export class SetupUtils {
 
-function install() {
-    return spawnProcessCheckExitCode(
-        PKEXEC,
-        SH,
-        INSTALLER,
-        '--prefix',
-        '/usr',
-        '--suffix',
-        TOOL_SUFFIX,
-        '--extension-path',
-        EXTENSIONDIR,
-        'install'
-    );
-}
+    /**
+     * 
+     * @param {Extension} extension 
+     */
+    constructor(extension) {
+        this.EXTENSIONDIR = extension.dir.get_path();
+        this.INSTALLER = `${this.EXTENSIONDIR}/scripts/installer.sh`;
+        this.TOOL_SUFFIX = GLib.get_user_name();
+        this.PKEXEC = GLib.find_program_in_path('pkexec');
+        this.SH = GLib.find_program_in_path('sh');
+    }
 
-function uninstall() {
-    return spawnProcessCheckExitCode(
-        PKEXEC,
-        SH,
-        INSTALLER,
-        '--prefix',
-        '/usr',
-        '--suffix',
-        TOOL_SUFFIX,
-        '--extension-path',
-        EXTENSIONDIR,
-        'uninstall'
-    );
-}
+    checkInstalled() {
+        return this._spawnProcessCheckExitCode(
+            this.SH,
+            this.INSTALLER,
+            '--prefix',
+            '/usr',
+            '--suffix',
+            this.TOOL_SUFFIX,
+            '--extension-path',
+            this.EXTENSIONDIR,
+            'check'
+        );
+    }
 
-function runScreenpadTool(pkexecNeeded, ...params) {
-    return runShellCmd(pkexecNeeded, '/usr/local/bin/screenpad-' + TOOL_SUFFIX, ...params);
-}
+    install() {
+        return this._spawnProcessCheckExitCode(
+            this.PKEXEC,
+            this.SH,
+            this.INSTALLER,
+            '--prefix',
+            '/usr',
+            '--suffix',
+            this.TOOL_SUFFIX,
+            '--extension-path',
+            this.EXTENSIONDIR,
+            'install'
+        );
+    }
 
-/**
- * Reads device product name (like 'Zenbook UX8402ZA_UX8402ZA')
- */
-async function getProductName() {
-    const ret = await runShellCmd(false, 'cat', '/sys/devices/virtual/dmi/id/product_name');
-    return ret.ok ? ret.stdout : null;
-}
+    uninstall() {
+        return this._spawnProcessCheckExitCode(
+            this.PKEXEC,
+            this.SH,
+            this.INSTALLER,
+            '--prefix',
+            '/usr',
+            '--suffix',
+            this.TOOL_SUFFIX,
+            '--extension-path',
+            this.EXTENSIONDIR,
+            'uninstall'
+        );
+    }
 
-function runShellCmd(pkexecNeeded, cmd, ...params) {
-    return new Promise((resolve, reject) => {
-        let args = [cmd].concat(params);
-
-        if (pkexecNeeded) {
-            args.unshift(PKEXEC);
-        }
-
-        let launcher = Gio.SubprocessLauncher.new(Gio.SubprocessFlags.STDOUT_PIPE);
-        launcher.set_cwd(EXTENSIONDIR);
-        let proc;
-        try {
-            proc = launcher.spawnv(args);
-        } catch (e) {
-            reject(e);
-            return;
-        }
-
-        let stdoutStream = new Gio.DataInputStream({
-            base_stream: proc.get_stdout_pipe(),
-            close_base_stream: true,
-        });
-        proc.wait_async(null, (proc, result) => {
-            // this only throws if async call got cancelled, but we
-            // explicitly passed null for the cancellable
-            let ok = proc.wait_finish(result);
+    _spawnProcessCheckExitCode(...argv) {
+        return new Promise((resolve, reject) => {
+            let [ok, pid, stdin, stdout, stderr] = GLib.spawn_async(
+                EXTENSIONDIR,
+                argv,
+                null,
+                GLib.SpawnFlags.DO_NOT_REAP_CHILD,
+                null
+            );
             if (!ok) {
                 reject();
                 return;
             }
-
-            let exitCode = proc.get_exit_status();
-            let [stdout, _length] = stdoutStream.read_upto('', 0, null);
-
-            resolve({
-                ok: exitCode === 0,
-                exitCode,
-                stdout,
+            GLib.child_watch_add(GLib.PRIORITY_DEFAULT, pid, (process, exitStatus) => {
+                GLib.spawn_close_pid(process);
+                let exitCode = 0;
+                try {
+                    GLib.spawn_check_exit_status(exitStatus);
+                } catch (e) {
+                    exitCode = e.code;
+                }
+    
+                resolve(exitCode);
             });
         });
-    });
+    }
 }

--- a/utils.js
+++ b/utils.js
@@ -92,8 +92,20 @@ function uninstall() {
 }
 
 function runScreenpadTool(pkexecNeeded, ...params) {
+    return runShellCmd(pkexecNeeded, '/usr/local/bin/screenpad-' + TOOL_SUFFIX, ...params);
+}
+
+/**
+ * Reads device product name (like 'Zenbook UX8402ZA_UX8402ZA')
+ */
+async function getProductName() {
+    const ret = await runShellCmd(false, 'cat', '/sys/devices/virtual/dmi/id/product_name');
+    return ret.ok ? ret.stdout : null;
+}
+
+function runShellCmd(pkexecNeeded, cmd, ...params) {
     return new Promise((resolve, reject) => {
-        let args = ['/usr/local/bin/screenpad-' + TOOL_SUFFIX].concat(params);
+        let args = [cmd].concat(params);
 
         if (pkexecNeeded) {
             args.unshift(PKEXEC);

--- a/utils.js
+++ b/utils.js
@@ -38,12 +38,14 @@ function spawnProcessCheckExitCode(...argv) {
     });
 }
 
-const EXIT_SUCCESS = 0,
-    EXIT_INVALID_ARGUMENT = 1,
-    EXIT_FAILURE = 2,
-    EXIT_NEEDS_UPDATE = 3,
-    EXIT_NOT_INSTALLED = 4,
-    EXIT_NEEDS_ROOT = 5;
+var ReturnCodes = Object.freeze({
+    EXIT_SUCCESS : 0,
+    EXIT_INVALID_ARGUMENT : 1,
+    EXIT_FAILURE : 2,
+    EXIT_NEEDS_UPDATE : 3,
+    EXIT_NOT_INSTALLED : 4,
+    EXIT_NEEDS_ROOT : 5,
+});
 
 function checkInstalled() {
     return spawnProcessCheckExitCode(


### PR DESCRIPTION
- Update to GNOME 45
- Screenpad-toggle key working again
- Extension disabling fixed (toggling extension state was creating multiple slider)
- Missing notifications if kernel module missing or support files not existing fixed
- README improved
- Code cleanup

Remaining issue:
- Settings window to small, needs to be resized by user manually to see complete page